### PR TITLE
Bugfix: 컴파일 인코딩 문제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ tasks.jar {
     }
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 run {
     // Fix ./gradlew run
     standardInput = System.in


### PR DESCRIPTION
- IDE 실행 환경에서 인코딩 기본값이 UTF-8 과 다르면 컴파일 오류가 발생함
- build.gradle 스크립트에서 compileJava task 인코딩 설정을 UTF-8 로 수정했음

bugfix 이후 #9 에서 제시된 IDE 추가 설정은 필요 없음.