### PR TITLE
Bugfix: #16 컬렉션 비동기 수정 해결

### DIFF
--- a/src/main/java/toast/impl/ToastProcess.java
+++ b/src/main/java/toast/impl/ToastProcess.java
@@ -86,7 +86,8 @@ public class ToastProcess implements Process {
         ++continuousBurstTime;
 
         if (isComplete()) {
-            completionListeners.forEach(Runnable::run);
+            List<Runnable> listeners = new ArrayList<>(completionListeners);
+            listeners.forEach(Runnable::run);
         }
     }
 


### PR DESCRIPTION
PR #15 에서 도입된 `Process#removeCompletionListener(index)` 메소드를 completion 리스너 내부에서 호출하면 `ConcurrentModificationException` 이 발생하는 문제를 해결하였음.